### PR TITLE
swap quotes instead of replace

### DIFF
--- a/scripts/CHGextension.py
+++ b/scripts/CHGextension.py
@@ -21,11 +21,13 @@ from modules.sd_samplers_timesteps import CompVisTimestepsDenoiser, CompVisTimes
 from modules.sd_samplers_cfg_denoiser import CFGDenoiser, catenate_conds, subscript_cond, pad_cond
 from modules import script_callbacks
 
+quote_swap = str.maketrans('\'"', '"\'')
+
 
 def pares_infotext(infotext, params):
     # parse infotext decode json string
     try:
-        params['CHG'] = json.loads(params['CHG'].replace("'", '"'))
+        params['CHG'] = json.loads(params['CHG'].translate(quote_swap))
     except Exception:
         pass
 
@@ -667,7 +669,7 @@ class ExtensionTemplateScript(scripts.Script):
                       checkbox, **kwargs):
         if checkbox:
             # info text will have to be written hear otherwise params.txt will not have the infotext of CHG
-            # write parameters to extra_generation_params["CHG"] as json dict with double quotes replaced by single quotes
+            # write parameters to extra_generation_params["CHG"] as json dict with double and single quotes swapped
             parameters = {
                 'RegS': reg_ini,
                 'RegR': reg_range,
@@ -680,7 +682,7 @@ class ExtensionTemplateScript(scripts.Script):
                 'AStrength': reg_w,
                 'AADim': aa_dim
             }
-            p.extra_generation_params["CHG"] = json.dumps(parameters).replace('"', "'")
+            p.extra_generation_params["CHG"] = json.dumps(parameters).translate(quote_swap)
 
     # Extension main process
     # Type: (StableDiffusionProcessing, List<UI>) -> (Processed)


### PR DESCRIPTION
this is inconsequential but I kind of cheap out a bit when I was implementing the infotext

I use a character `replace` of double quotes to single quotes as opposed to a character `swap`
which is totally fine as I assume that the values will only be sanitized values with no single quotes is used

but in the future if you decide for whatever reason single is used quotes infotext, it will break

in the PR I did a simple remedy by using `str.translate` to swap single quotes and double quotes
this way for whatever reason if in the future you do indeed wants to put a single quote inside there will be no issue

there's no compatibility issues

---

I think I forgotten to explain why I replaced up because with single quotes in the first place

the reason is that the infotext string would be serialized as json string "again" by webui
as json string format double quotes will have to be escaped by using a backslash `"` -> `\"`
and would cause the infotax to be messy

if the quotes are not swapped you will end up with something like this
```
CHG: "{\"RegS\": 0.7, \"RegR\": 1.28, \"MaxI\": 23, \"NBasis\": 2, \"Reuse\": 0.05, \"Tol\": -4.2, \"IteSS\": 0.82, \"ASpeed\": 0.4, \"AStrength\": 0.76, \"AADim\": 2}"
```
compared to if we swap them you will get a much clearer infotext
```
CHG: "{'RegS': 0.7, 'RegR': 1.28, 'MaxI': 23, 'NBasis': 2, 'Reuse': 0.05, 'Tol': -4.2, 'IteSS': 0.82, 'ASpeed': 0.4, 'AStrength': 0.76, 'AADim': 2}"
```

---

also a FYI
if you wish to compact the json string even more by removing the spaces, you can do so specifying to separator arg for `json.dumps`
```py
json.dumps({'a':[1,2], 'b': 'bbb'}, separators=(',', ':'))
# {"a":[1,2],"b":"bbb"}'
```
but you would lose a bit of readability
```
"{'RegS':0.7,'RegR':1.28,'MaxI':23,'NBasis':2,'Reuse':0.05,'Tol':-4.2,'IteSS':0.82,'ASpeed':0.4,'AStrength':0.76,'AADim':2}"
```
if you wish to take it a step further
you can even use CSV string and split key value colon

and if you don't care about readability at all, you can even use a list with out the key
note not advisable as without the keys you have to make sure that the order of the args never change

> note: in my opinion how it is now is totally fine I'm just providing information because I'm "bored"