### PR TITLE
Add new slider controls

### DIFF
--- a/scripts/CHGextension.py
+++ b/scripts/CHGextension.py
@@ -879,7 +879,7 @@ class ExtensionTemplateScript(scripts.Script):
         def modified_sample(sample):
             def wrapper(self, conditioning, unconditional_conditioning, seeds, subseeds, subseed_strength, prompts):
                 def _call_forward(self, *args, **kwargs):
-                    if self.start_step <= self.step < self.stop_step:
+                    if self.chg_start_step <= self.step < self.chg_stop_step:
                         return CHGDenoiser.forward(self, *args, **kwargs)
                     else:
                         return CFGDenoiser.forward(self, *args, **kwargs)
@@ -914,8 +914,8 @@ class ExtensionTemplateScript(scripts.Script):
                     CFGDenoiser.process_p = p
                     CFGDenoiser.radio_controlnet = radio
                     constrain_step = lambda total_step, step_pct: max(0, min(round(total_step * step_pct), total_step))
-                    CFGDenoiser.start_step = constrain_step(p.steps, start_step)
-                    CFGDenoiser.stop_step = constrain_step(p.steps, stop_step)
+                    CFGDenoiser.chg_start_step = constrain_step(p.steps, start_step)
+                    CFGDenoiser.chg_stop_step = constrain_step(p.steps, stop_step)
                     # CFGDenoiser.CFGdecayS = CFGdecayS
                     try:
                         print("Characteristic Guidance sampling:")

--- a/scripts/CHGextension.py
+++ b/scripts/CHGextension.py
@@ -715,7 +715,7 @@ class ExtensionTemplateScript(scripts.Script):
 
     # Setup menu ui detail
     def ui(self, is_img2img):
-        with gr.Accordion('Characteristic Guidance', open=False):
+        with gr.Accordion('Characteristic Guidance (CHG)', open=False):
             reg_ini = gr.Slider(
                 minimum=0.0,
                 maximum=10.,
@@ -750,14 +750,14 @@ class ExtensionTemplateScript(scripts.Script):
                     maximum=0.25,
                     step=0.01,
                     value=0.0,
-                    label="CHG Start Step ( → Use CFG before Percent of Steps, Closer to Classifier-Free.)",
+                    label="CHG Start Step ( Use CFG before Percent of Steps. )",
                 )
                 stop_step = gr.Slider(
                     minimum=0.25,
                     maximum=1.0,
                     step=0.01,
                     value=1.0,
-                    label="CHG End Step ( → Use CFG after Percent of Steps, Closer to Classifier-Free.)",
+                    label="CHG End Step ( Use CFG after Percent of Steps. )",
                 )
             with gr.Accordion('Advanced', open=False):
                 chara_decay = gr.Slider(

--- a/scripts/CHGextension.py
+++ b/scripts/CHGextension.py
@@ -108,12 +108,6 @@ def proj_least_squares(A, B, reg):
 class CHGDenoiser(CFGDenoiser):
     def __init__(self, sampler):
         super().__init__(sampler)
-    
-    # def _call_forward(self, *args, **kwargs):
-    #     if self.step < self.stop_step:
-    #         return CHGDenoiser.Chara_forward(self, *args, **kwargs)
-    #     else:
-    #         return CFGDenoiser.forward(self, *args, **kwargs)
 
     def forward(self, x, sigma, uncond, cond, cond_scale, s_min_uncond, image_cond):
         if state.interrupted or state.skipped:

--- a/scripts/CHGextension.py
+++ b/scripts/CHGextension.py
@@ -758,7 +758,6 @@ class ExtensionTemplateScript(scripts.Script):
                     step=0.01,
                     value=1.0,
                     label="CHG End Step ( → Use CFG after Percent of Steps, Closer to Classifier-Free.)",
-                    label="Use CFG after Percent Step ( → Lower Quality, Closer to Classifier-Free.)",
                 )
                 n_step = gr.Slider(
                     minimum=1,

--- a/scripts/CHGextension.py
+++ b/scripts/CHGextension.py
@@ -747,13 +747,13 @@ class ExtensionTemplateScript(scripts.Script):
             with gr.Row(open=True):
                 start_step = gr.Slider(
                     minimum=0.0,
-                    maximum=1.0,
+                    maximum=0.25,
                     step=0.01,
                     value=0.0,
                     label="CHG Start Step ( → Use CFG before Percent of Steps, Closer to Classifier-Free.)",
                 )
                 stop_step = gr.Slider(
-                    minimum=0.0,
+                    minimum=0.25,
                     maximum=1.0,
                     step=0.01,
                     value=1.0,
@@ -882,7 +882,7 @@ class ExtensionTemplateScript(scripts.Script):
                     if self.start_step <= self.step < self.stop_step:
                         return CHGDenoiser.forward(self, *args, **kwargs)
                     else:
-                        return original_forward(self, *args, **kwargs)
+                        return CFGDenoiser.forward(self, *args, **kwargs)
                 # modules = sys.modules
                 if checkbox:
                     # from ssd_samplers_chg_denoiser import CFGDenoiser as CHGDenoiser


### PR DESCRIPTION
First of all, thank you for your excellent extension. I have found that Characteristic Guidance improves image quality and composition by a huge margin.

My main frustration is how long the CHG iteration process can take, given that convergence is not guaranteed. This PR adds two new controls to the UI in an attempt to improve image generation throughput: 

- *"Use CFG after Percent Step"*
	Enables switching from CHG to CFG after a certain percent of steps has passed.

- *"Use Characteristic Guidance each n steps"*
	Uses CHG every n steps and runs CFG for every other step.

The motivation behind *"Use CFG after Percent Step"* is the observation that the first 30-40% steps alter the image much more than the remaining steps. By setting it to a value like 0.4, it keeps the first 40% steps using CHG where it would have the most effect, then using CFG the rest of the steps 

Alternatively, *"Use Characteristic Guidance each n steps"* allows alternating between CHG and CFG every n steps. This effectively reduces the number of times CHG runs by a factor of n while still improving image quality.

On a technical note, this PR replaces the forward method with _call_forward, which has the if condition which runs either CHG or CFG if the condition is not met. The default parameter settings will retain the behavior of the extension as it is now.

---
Please see some examples here:  

### New slider controls on the UI:
![new_controls](https://github.com/scraed/CharacteristicGuidanceWebUI/assets/28695009/e425b9a0-2c4d-4baf-91f4-88ac8808fd61)

### Image comparison between running CHG every step vs only the first 30% of steps:
![stop_step_comparison](https://github.com/scraed/CharacteristicGuidanceWebUI/assets/28695009/77c90707-a546-4b5d-8e8c-d6b8b1540947)

### Image grid comparing generations using both *"Use CFG after Percent Step"* and *"Use Characteristic Guidance each n steps"*:
![comparison](https://github.com/scraed/CharacteristicGuidanceWebUI/assets/28695009/f02d9181-1390-4346-8afa-b906c93cfe1e)

---

Somewhat unrelated to this PR, but definitely notable, is that enabling the extension effectively fixes the high CFG problem with ControlNet InstantID. This works even if no CHG steps are ever run (by setting "Use CFG after Percent Step" to 0).

![instantid_comparison](https://github.com/scraed/CharacteristicGuidanceWebUI/assets/28695009/342dbf85-928f-494a-80c7-84e201b44720)

