### PR TITLE
Fix import statements for compatibility with `--data-dir` option.

### DIFF
--- a/scripts/CHGextension.py
+++ b/scripts/CHGextension.py
@@ -20,7 +20,7 @@ from k_diffusion.external import CompVisVDenoiser, CompVisDenoiser
 from modules.sd_samplers_timesteps import CompVisTimestepsDenoiser, CompVisTimestepsVDenoiser
 from modules.sd_samplers_cfg_denoiser import CFGDenoiser, catenate_conds, subscript_cond, pad_cond
 from modules import script_callbacks
-from extensions.CharacteristicGuidanceWebUI.scripts.CharaIte import Chara_iteration
+from scripts.CharaIte import Chara_iteration
 
 try:
     from modules_forge import forge_sampler
@@ -45,11 +45,11 @@ script_callbacks.on_infotext_pasted(pares_infotext)
 
 
 if not isForge:
-    from extensions.CharacteristicGuidanceWebUI.scripts.webui_CHG import CHGdenoiserConstruct
+    from scripts.webui_CHG import CHGdenoiserConstruct
     exec( CHGdenoiserConstruct() )
 else:
-    from extensions.CharacteristicGuidanceWebUI.scripts.forge_CHG import CHGdenoiserConstruct
-    import extensions.CharacteristicGuidanceWebUI.scripts.forge_CHG as forge_CHG
+    from scripts.forge_CHG import CHGdenoiserConstruct
+    import scripts.forge_CHG as forge_CHG
     exec( CHGdenoiserConstruct() )
 
 

--- a/scripts/forge_CHG.py
+++ b/scripts/forge_CHG.py
@@ -34,7 +34,7 @@ try:
 except Exception:
     isForge = False
 
-from extensions.CharacteristicGuidanceWebUI.scripts.CharaIte import Chara_iteration
+from scripts.CharaIte import Chara_iteration
 
 # 1st edit by https://github.com/comfyanonymous/ComfyUI
 # 2nd edit by Forge Official


### PR DESCRIPTION
A1111 provides an option to have a separate datadir to avoid cluttering the same directory and separate the concerns, using a `--data-dir <path>` option.

Let's say we create a directory `stable-diffusion-webui.data` next to the cloned `stable-diffusion-webui`

webui-user-datadir.bat:
```bat
@echo off

cd ..
cd stable-diffusion-webui

set PYTHON=
set GIT=
set VENV_DIR=
set COMMANDLINE_ARGS=--data-dir ../stable-diffusion-webui.data

call webui.bat
```

Many extensions handle this fine, but this extension expects to reside inside stable-diffusion-webui directory, instead of importing itself relative to datadir:
```python
*** Error loading script: CHGextension.py
    Traceback (most recent call last):
      File "C:\homesync\stable-diffusion-webui\modules\scripts.py", line 515, in load_scripts
        script_module = script_loading.load_module(scriptfile.path)
      File "C:\homesync\stable-diffusion-webui\modules\script_loading.py", line 13, in load_module
        module_spec.loader.exec_module(module)
      File "<frozen importlib._bootstrap_external>", line 883, in exec_module
      File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
      File "C:\homesync\stable-diffusion-webui\../stable-diffusion-webui.data\extensions\CharacteristicGuidanceWebUI\scripts\CHGextension.py", line 48, in <module>
        from extensions.CharacteristicGuidanceWebUI.scripts.webui_CHG import CHGdenoiserConstruct
    ModuleNotFoundError: No module named 'extensions.CharacteristicGuidanceWebUI'
```

After inspecting how other extensions do it, I've found that this is easily fixable by changing import statements.

Solution:
```diff
diff --git a/scripts/CHGextension.py b/scripts/CHGextension.py
index d07a529..2dd16bc 100644
--- a/scripts/CHGextension.py
+++ b/scripts/CHGextension.py
@@ -20,7 +20,7 @@ from k_diffusion.external import CompVisVDenoiser, CompVisDenoiser
 from modules.sd_samplers_timesteps import CompVisTimestepsDenoiser, CompVisTimestepsVDenoiser
 from modules.sd_samplers_cfg_denoiser import CFGDenoiser, catenate_conds, subscript_cond, pad_cond
 from modules import script_callbacks
-from extensions.CharacteristicGuidanceWebUI.scripts.CharaIte import Chara_iteration
+from scripts.CharaIte import Chara_iteration
 
 try:
     from modules_forge import forge_sampler
@@ -45,11 +45,11 @@ script_callbacks.on_infotext_pasted(pares_infotext)
 
 
 if not isForge:
-    from extensions.CharacteristicGuidanceWebUI.scripts.webui_CHG import CHGdenoiserConstruct
+    from scripts.webui_CHG import CHGdenoiserConstruct
     exec( CHGdenoiserConstruct() )
 else:
-    from extensions.CharacteristicGuidanceWebUI.scripts.forge_CHG import CHGdenoiserConstruct
-    import extensions.CharacteristicGuidanceWebUI.scripts.forge_CHG as forge_CHG
+    from scripts.forge_CHG import CHGdenoiserConstruct
+    import scripts.forge_CHG as forge_CHG
     exec( CHGdenoiserConstruct() )
 
 
diff --git a/scripts/forge_CHG.py b/scripts/forge_CHG.py
index ee108e9..603defd 100644
--- a/scripts/forge_CHG.py
+++ b/scripts/forge_CHG.py
@@ -34,7 +34,7 @@ try:
 except Exception:
     isForge = False
 
-from extensions.CharacteristicGuidanceWebUI.scripts.CharaIte import Chara_iteration
+from scripts.CharaIte import Chara_iteration
 
 # 1st edit by https://github.com/comfyanonymous/ComfyUI
 # 2nd edit by Forge Official
```

As a bonus, we're no longer hardcoding our extension directory in the filesystem as well.
